### PR TITLE
Fix code scanning alert no. 37: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ module.exports = function trackOrder () {
     const id = utils.disableOnContainerEnv() ? String(req.params.id).replace(/[^\w-]+/g, '') : req.params.id
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.orders.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.orders.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Fixes [https://github.com/charlenemckeown-org/juice-shop/security/code-scanning/37](https://github.com/charlenemckeown-org/juice-shop/security/code-scanning/37)

To fix the problem, we should avoid using the `$where` operator with user input. Instead, we can use a parameterized query to safely query the database. This approach ensures that user input is treated as data rather than code, preventing code injection attacks.

We will replace the `$where` query with a standard MongoDB query that uses the `orderId` field directly. This change will be made in the `routes/trackOrder.ts` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
