### PR TITLE
Fix code scanning alert no. 9: Template Object Injection

### DIFF
--- a/routes/dataErasure.ts
+++ b/routes/dataErasure.ts
@@ -69,8 +69,10 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       const filePath: string = path.resolve(req.body.layout).toLowerCase()
       const isForbiddenFile: boolean = (filePath.includes('ftp') || filePath.includes('ctf.key') || filePath.includes('encryptionkeys'))
       if (!isForbiddenFile) {
+        const { email, securityAnswer } = req.body;
         res.render('dataErasureResult', {
-          ...req.body
+          email,
+          securityAnswer
         }, (error, html) => {
           if (!html || error) {
             next(new Error(error.message))
@@ -84,8 +86,10 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
         next(new Error('File access not allowed'))
       }
     } else {
+      const { email, securityAnswer } = req.body;
       res.render('dataErasureResult', {
-        ...req.body
+        email,
+        securityAnswer
       })
     }
   } catch (error) {


### PR DESCRIPTION
Fixes [https://github.com/charlenemckeown-org/juice-shop/security/code-scanning/9](https://github.com/charlenemckeown-org/juice-shop/security/code-scanning/9)

To fix the problem, we need to avoid using the entire `req.body` object directly in the `res.render` function. Instead, we should explicitly construct an object with only the necessary properties required by the template. This will prevent any unintended properties from being used in the template rendering process.

1. Identify the specific properties needed by the `dataErasureResult` template.
2. Construct an object with only those properties from `req.body`.
3. Use the constructed object in the `res.render` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
